### PR TITLE
Update Example in DACS 6.2.3

### DIFF
--- a/06_part_I/07_chapter_06/02_existence_and_location_of_copies.md
+++ b/06_part_I/07_chapter_06/02_existence_and_location_of_copies.md
@@ -22,7 +22,7 @@ This element indicates the existence, location, and availability of copies or ot
 <p class="dacs-example">Microfilm copies available for interlibrary loan.</p>
 <p class="dacs-example">Diaries available on microfilm for use in repository only.</p>
 <p class="dacs-example">Digital reproductions of the Christie family Civil War correspondence are available electronically at http://www.mnhs.org/collections/christie.html.</p>
-<p class="dacs-example">The diary has been published in Dunlap, Kate. <em>The Montana Gold Rush Diary of Kate Dunlap, edited and annotated by J. Lyman Tyler</em> Denver: F. A. Rosenstock Old West Publishing Co., 1969.</p>
+<p class="dacs-example">The diary has been published in Dunlap, Kate. <em>The Montana Gold Rush Diary of Kate Dunlap, edited and annotated by J. Lyman Tyler</em> Denver: F. A. Rosenstock Old West Publishing Co., 1969. A physical copy of the publication is available for checkout at the Harold B. Lee Library (Call Number F 594 .D85 1969).</p>
 **6.2.4** If appropriate, record information to distinguish between multiple generations of the material.
 
 <p class="dacs-example">Prints in this series made from copy negatives, produced in 1974, of the original photographs.</p>


### PR DESCRIPTION
Closes #15

Change request submitted by Matthew Gorham based on issue #15 

**Proposed change**
-  Update the last example in 6.2.3 to clarify that it describes the existence of a copy of the material being described that is available for use at the same institution, per the general rules of 6.2.3.

**Justification for proposed change**
- The examples used in elements 6.2.3 and 6.4.4 both include an example of a published, annotated version of archival materials, yet it is unclear whether an annotated publication should be described only using 6.4.4 or if it can be described using 6.2.3 as well. This revision will clarify that an annotated publication (or any other published version of archival material) should only be described using 6.2.3 if the material being described is a copy of original archival material held by the same institution and is available for use at that institution.

**Impact of proposed change**
- This change will clarify when it is appropriate to describe a publication using element 6.2, and when it is appropriate to do so using element 6.4.